### PR TITLE
Allow specifying core route table id

### DIFF
--- a/deployments/awscc/lab/main.tf
+++ b/deployments/awscc/lab/main.tf
@@ -4,10 +4,6 @@ module "common_ssh" {
     public_key_file_path = var.public_key_file
 }
 
-data "aws_route_table" "core_priv" {
-  subnet_id = var.core_priv_subnet_id
-}
-
 # module "s3_endpoint" {
 #     source      = "../../../lib/awscc/s3_endpoint"
 #     vpc_id      = module.network.vpc_id
@@ -139,7 +135,7 @@ module "ec2_endpoint" {
   source              = "../../../lib/awscc/endpoints"
   vpc_id              = var.vpc_id
   subnet_ids          = [var.core_priv_subnet_id]
-  route_table_ids     = [data.aws_route_table.core_priv.id]
+  route_table_ids     = [var.core_priv_route_table_id]
   private_dns_enabled = true
   region              = var.region
   tags = {

--- a/deployments/awscc/lab/terraform.tfvars
+++ b/deployments/awscc/lab/terraform.tfvars
@@ -2,6 +2,8 @@
 vpc_id              = "12345678"
 core_priv_subnet_id = "87654321"
 engines_priv_subnet_id = "963258741"
+# ID for the core private subnet's route table
+core_priv_route_table_id = "rtb-COREPRIV"
 # Replace the following placeholder IDs with real subnet IDs
 entry_pub_subnet_id   = "subnet-ENTRY"
 

--- a/deployments/awscc/lab/vars.tf
+++ b/deployments/awscc/lab/vars.tf
@@ -71,6 +71,11 @@ variable "core_priv_subnet_id" {
   description = "ID of existing core private subnet"
 }
 
+variable "core_priv_route_table_id" {
+  type        = string
+  description = "ID of the route table associated with the core private subnet"
+}
+
 variable "entry_pub_subnet" {
   type        = map(string)
   description = "pub subnet for vpn. required keys: cidr_block, cidr_reserved_block."


### PR DESCRIPTION
## Summary
- allow specifying EC2 endpoint route table via variable
- add `core_priv_route_table_id` to vars and sample tfvars

## Testing
- `terraform fmt main.tf vars.tf terraform.tfvars` *(fails: command not found)*
- `terraform validate` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*


------
https://chatgpt.com/codex/tasks/task_b_68a48598a924832ba744d99c12ef20bf